### PR TITLE
Fix: Don't try to remove the same source more than once.

### DIFF
--- a/apx/lib/graphics.py
+++ b/apx/lib/graphics.py
@@ -2071,6 +2071,7 @@ class Scene(Parent, gtk.DrawingArea):
     def __on_mouse_move(self, scene, event):
         if self.__last_mouse_move:
             gobject.source_remove(self.__last_mouse_move)
+            self.__last_mouse_move = None
 
         self.mouse_x, self.mouse_y = event.x, event.y
 


### PR DESCRIPTION
While playing, I got a lot of warnings at the console, like
````
/usr/lib/python2.7/site-packages/apx/lib/graphics.py:2073: Warning: Source ID 999 was not found when attempting to remove it
  gobject.source_remove(self.__last_mouse_move)
````

On first look, it seems like dropping the resource was forgotten
(Edit: I tried playing with this patch, and I didn't have the warnings any more.)